### PR TITLE
Scroll to top

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,11 +3,11 @@ import "./App.scss";
 import Home from "./pages/Home/Home";
 import Register from "./pages/Register/Register";
 import DashBoard from "./pages/DashBoard/DashBoard";
+import ScrollToTop from "./components/UtilComponents/ScrollToTop";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { useState } from "react";
 import FindBuddies from "./pages/FindBuddies/FindBuddies";
 import Footer from "./components/Footer/Footer";
-
 
 function App() {
     const [isOnHomePage, setIsOnHomePage] = useState(true);
@@ -15,6 +15,7 @@ function App() {
 
     return (
         <BrowserRouter>
+            <ScrollToTop />
             <Routes>
                 <Route
                     path="/"

--- a/frontend/src/components/UtilComponents/ScrollToTop.js
+++ b/frontend/src/components/UtilComponents/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+}

--- a/frontend/src/components/UtilComponents/ScrollToTop.js
+++ b/frontend/src/components/UtilComponents/ScrollToTop.js
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
+
+// Prevents default scroll restoration, see https://v5.reactrouter.com/web/guides/scroll-restoration
 export default function ScrollToTop() {
     const { pathname } = useLocation();
 


### PR DESCRIPTION
Added a scrollToTop component in line with https://v5.reactrouter.com/web/guides/scroll-restoration to prevent restoration of scroll history (e.g. when scrolled down to the footer on the findBuddies page and then clicked home in the menu, it lead to the footer in the home page, now it scrolls to top). 